### PR TITLE
Add handling for nil values

### DIFF
--- a/dump.go
+++ b/dump.go
@@ -226,11 +226,13 @@ func createTableValues(db *sql.DB, name string) (string, error) {
 
 		for key, value := range data {
 			if value != nil && value.Valid {
-				dataStrings[key] = value.String
+				dataStrings[key] = "'" + value.String + "'"
+			} else {
+				dataStrings[key] = "null"
 			}
 		}
 
-		data_text = append(data_text, "('"+strings.Join(dataStrings, "','")+"')")
+		data_text = append(data_text, "("+strings.Join(dataStrings, ",")+")")
 	}
 
 	return strings.Join(data_text, ","), rows.Err()

--- a/dump_test.go
+++ b/dump_test.go
@@ -175,7 +175,8 @@ func TestCreateTableValuesNil(t *testing.T) {
 
 	rows := sqlmock.NewRows([]string{"id", "email", "name"}).
 		AddRow(1, nil, "Test Name 1").
-		AddRow(2, "test2@test.de", "Test Name 2")
+		AddRow(2, "test2@test.de", "Test Name 2").
+		AddRow(3, "", "Test Name 3")
 
 	mock.ExpectQuery("^SELECT (.+) FROM test$").WillReturnRows(rows)
 
@@ -189,7 +190,7 @@ func TestCreateTableValuesNil(t *testing.T) {
 		t.Errorf("there were unfulfilled expections: %s", err)
 	}
 
-	expectedResult := "('1','','Test Name 1'),('2','test2@test.de','Test Name 2')"
+	expectedResult := "('1',null,'Test Name 1'),('2','test2@test.de','Test Name 2'),('3','','Test Name 3')"
 
 	if !reflect.DeepEqual(result, expectedResult) {
 		t.Fatalf("expected %#v, got %#v", expectedResult, result)
@@ -227,7 +228,7 @@ func TestCreateTableOk(t *testing.T) {
 	expectedResult := &table{
 		Name:   "Test_Table",
 		SQL:    "CREATE TABLE 'Test_Table' (`id` int(11) NOT NULL AUTO_INCREMENT,`s` char(60) DEFAULT NULL, PRIMARY KEY (`id`))ENGINE=InnoDB DEFAULT CHARSET=latin1",
-		Values: "('1','','Test Name 1'),('2','test2@test.de','Test Name 2')",
+		Values: "('1',null,'Test Name 1'),('2','test2@test.de','Test Name 2')",
 	}
 
 	if !reflect.DeepEqual(result, expectedResult) {
@@ -323,7 +324,7 @@ CREATE TABLE 'Test_Table' (\id\ int(11) NOT NULL AUTO_INCREMENT,\email\ char(60)
 LOCK TABLES Test_Table WRITE;
 /*!40000 ALTER TABLE Test_Table DISABLE KEYS */;
 
-INSERT INTO Test_Table VALUES ('1','','Test Name 1'),('2','test2@test.de','Test Name 2');
+INSERT INTO Test_Table VALUES ('1',null,'Test Name 1'),('2','test2@test.de','Test Name 2');
 
 /*!40000 ALTER TABLE Test_Table ENABLE KEYS */;
 UNLOCK TABLES;


### PR DESCRIPTION
If the value in the database is null it
should also be null when inserting it again.
Before an empty string was generated and this
can lead to problems with indexes and constraints.

A combined unique index like locale,uri where the uri
is optional would throw an duplicate Error when you
insert multiple values like this:

'de_ch',''
'de_ch',''

The correct way to insert these:

'de_ch',null
'de_ch',null

And will not throw any errors.