### PR TITLE
Add escape table name

### DIFF
--- a/dump.go
+++ b/dump.go
@@ -174,7 +174,7 @@ func createTableSQL(db *sql.DB, name string) (string, error) {
 	// Get table creation SQL
 	var table_return sql.NullString
 	var table_sql sql.NullString
-	err := db.QueryRow("SHOW CREATE TABLE "+name).Scan(&table_return, &table_sql)
+	err := db.QueryRow("SHOW CREATE TABLE `"+name+"`").Scan(&table_return, &table_sql)
 
 	if err != nil {
 		return "", err
@@ -188,7 +188,7 @@ func createTableSQL(db *sql.DB, name string) (string, error) {
 
 func createTableValues(db *sql.DB, name string) (string, error) {
 	// Get Data
-	rows, err := db.Query("SELECT * FROM " + name)
+	rows, err := db.Query("SELECT * FROM `" + name + "`")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Without escape  generate error "You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'order' at line 1"
if table name is  `order`