### PR TITLE
Modify the output file format and add a prefix

### DIFF
--- a/dump.go
+++ b/dump.go
@@ -23,7 +23,7 @@ type dump struct {
 	CompleteTime  string
 }
 
-const version = "0.2.3"
+const version = "0.2.5"
 
 const tmpl = `-- Go SQL Dump {{ .DumpVersion }}
 --
@@ -227,7 +227,7 @@ func createTableValues(db *sql.DB, name string) (string, error) {
 
 		for key, value := range data {
 			if value != nil && value.Valid {
-				dataStrings[key] = "'" + value.String + "'"
+				dataStrings[key] = "'" + escapeString(value.String) + "'"
 			} else {
 				dataStrings[key] = "null"
 			}
@@ -236,5 +236,26 @@ func createTableValues(db *sql.DB, name string) (string, error) {
 		data_text = append(data_text, "("+strings.Join(dataStrings, ",")+")")
 	}
 
-	return strings.Join(data_text, ","), rows.Err()
+	return strings.Join(data_text, ","), rows.Err()j
+}
+
+func escapeString(str string) string {
+	replace := map[string]string{
+		`\`: `\\`,
+	}
+
+	for b, a := range replace {
+		str = strings.Replace(str, b, a, -1)
+	}
+
+	replace = map[string]string{
+		"'": `\'`,
+		`"`: `\"`,
+	}
+
+	for b, a := range replace {
+		str = strings.Replace(str, b, a, -1)
+	}
+
+	return str
 }

--- a/dump.go
+++ b/dump.go
@@ -175,7 +175,7 @@ func createTableSQL(db *sql.DB, name string) (string, error) {
 	// Get table creation SQL
 	var table_return sql.NullString
 	var table_sql sql.NullString
-	err := db.QueryRow("SHOW CREATE TABLE "+name).Scan(&table_return, &table_sql)
+	err := db.QueryRow("SHOW CREATE TABLE `"+name+"`").Scan(&table_return, &table_sql)
 
 	if err != nil {
 		return "", err
@@ -189,7 +189,7 @@ func createTableSQL(db *sql.DB, name string) (string, error) {
 
 func createTableValues(db *sql.DB, name string) (string, error) {
 	// Get Data
-	rows, err := db.Query("SELECT * FROM " + name)
+	rows, err := db.Query("SELECT * FROM `" + name + "`")
 	if err != nil {
 		return "", err
 	}

--- a/dump.go
+++ b/dump.go
@@ -23,7 +23,7 @@ type dump struct {
 	CompleteTime  string
 }
 
-const version = "0.2.5"
+const version = "0.2.6"
 
 const tmpl = `-- Go SQL Dump {{ .DumpVersion }}
 --

--- a/dump.go
+++ b/dump.go
@@ -23,7 +23,7 @@ type dump struct {
 	CompleteTime  string
 }
 
-const version = "0.2.2"
+const version = "0.2.3"
 
 const tmpl = `-- Go SQL Dump {{ .DumpVersion }}
 --
@@ -69,8 +69,9 @@ UNLOCK TABLES;
 
 // Creates a MYSQL Dump based on the options supplied through the dumper.
 func (d *Dumper) Dump() (string, error) {
-	name := time.Now().Format(d.format)
-	p := path.Join(d.dir, name+".sql")
+	format := time.Now().Format(d.format)
+	name := d.prefix + "-" + format + ".sql"
+	p := path.Join(d.dir, name)
 
 	// Check dump directory
 	if e, _ := exists(p); e {

--- a/dump.go
+++ b/dump.go
@@ -236,7 +236,7 @@ func createTableValues(db *sql.DB, name string) (string, error) {
 		data_text = append(data_text, "("+strings.Join(dataStrings, ",")+")")
 	}
 
-	return strings.Join(data_text, ","), rows.Err()j
+	return strings.Join(data_text, ","), rows.Err()
 }
 
 func escapeString(str string) string {

--- a/mysqldump.go
+++ b/mysqldump.go
@@ -11,6 +11,7 @@ type Dumper struct {
 	db     *sql.DB
 	format string
 	dir    string
+	prefix string
 }
 
 /*
@@ -20,7 +21,7 @@ Creates a new dumper.
 	dir: Path to the directory where the dumps will be stored.
 	format: Format to be used to name each dump file. Uses time.Time.Format (https://golang.org/pkg/time/#Time.Format). format appended with '.sql'.
 */
-func Register(db *sql.DB, dir, format string) (*Dumper, error) {
+func Register(db *sql.DB, dir, format, prefix string) (*Dumper, error) {
 	if !isDir(dir) {
 		return nil, errors.New("Invalid directory")
 	}
@@ -29,6 +30,7 @@ func Register(db *sql.DB, dir, format string) (*Dumper, error) {
 		db:     db,
 		format: format,
 		dir:    dir,
+		prefix: prefix,
 	}, nil
 }
 


### PR DESCRIPTION
dumpFilenameFormat := fmt.Sprintf("%s-20060102_150405", "testdb1")   --> testdb10-xxxxxxxx_xxxxxx.sql 

testdb1 to testdb10.

this commit fix the bug.