### PR TITLE
Added an option to not include the dump date in the output file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.idea/*
 vendor/*

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ func main() {
 	}
 
 	// Register database with mysqldump
-	dumper, err := mysqldump.Register(db, dumpDir, dumpFilenameFormat)
+	dumper, err := mysqldump.Register(db, dumpDir, dumpFilenameFormat, true)
 	if err != nil {
 		fmt.Println("Error registering databse:", err)
 		return

--- a/doc.go
+++ b/doc.go
@@ -27,7 +27,7 @@ This example uses the mymysql driver (example 7 https://github.com/ziutek/mymysq
         }
 
         // Register database with mysqldump
-        dumper, err := mysqldump.Register(db, "dumps", time.ANSIC)
+        dumper, err := mysqldump.Register(db, "dumps", time.ANSIC, true)
         if err != nil {
         	fmt.Println("Error registering databse:", err)
         	return

--- a/dump.go
+++ b/dump.go
@@ -64,8 +64,9 @@ INSERT INTO {{ .Name }} VALUES {{ .Values }};
 /*!40000 ALTER TABLE {{ .Name }} ENABLE KEYS */;
 UNLOCK TABLES;
 {{ end }}
+{{ if .CompleteTime }}
 -- Dump completed on {{ .CompleteTime }}
-`
+{{ end }}`
 
 // Creates a MYSQL Dump based on the options supplied through the dumper.
 func (d *Dumper) Dump() (string, error) {
@@ -112,7 +113,9 @@ func (d *Dumper) Dump() (string, error) {
 	}
 
 	// Set complete time
-	data.CompleteTime = time.Now().String()
+	if d.includeDumpDate {
+		data.CompleteTime = time.Now().String()
+	}
 
 	// Write dump to file
 	t, err := template.New("mysqldump").Parse(tmpl)

--- a/dump.go
+++ b/dump.go
@@ -23,7 +23,7 @@ type dump struct {
 	CompleteTime  string
 }
 
-const version = "0.2.2"
+const version = "0.3.0"
 
 const tmpl = `-- Go SQL Dump {{ .DumpVersion }}
 --

--- a/dump_test.go
+++ b/dump_test.go
@@ -267,9 +267,10 @@ func TestDumpOk(t *testing.T) {
 	mock.ExpectQuery("^SELECT (.+) FROM Test_Table$").WillReturnRows(createTableValueRows)
 
 	dumper := &Dumper{
-		db:     db,
-		format: "test_format",
-		dir:    "/tmp/",
+		db:              db,
+		format:          "test_format",
+		dir:             "/tmp/",
+		includeDumpDate: false,
 	}
 
 	path, err := dumper.Dump()
@@ -288,7 +289,7 @@ func TestDumpOk(t *testing.T) {
 		t.Errorf("error was not expected while reading the file: %s", err)
 	}
 
-	result := strings.Replace(strings.Split(string(f), "-- Dump completed")[0], "`", "\\", -1)
+	result := strings.Replace(string(f), "`", "\\", -1)
 
 	expected := `-- Go SQL Dump ` + version + `
 --

--- a/mysqldump.go
+++ b/mysqldump.go
@@ -8,9 +8,10 @@ import (
 
 // Dumper represents a database.
 type Dumper struct {
-	db     *sql.DB
-	format string
-	dir    string
+	db              *sql.DB
+	format          string
+	dir             string
+	includeDumpDate bool
 }
 
 /*
@@ -19,16 +20,18 @@ Creates a new dumper.
 	db: Database that will be dumped (https://golang.org/pkg/database/sql/#DB).
 	dir: Path to the directory where the dumps will be stored.
 	format: Format to be used to name each dump file. Uses time.Time.Format (https://golang.org/pkg/time/#Time.Format). format appended with '.sql'.
+	includeDumpDate: Whether the dump date should be included in the output.
 */
-func Register(db *sql.DB, dir, format string) (*Dumper, error) {
+func Register(db *sql.DB, dir, format string, includeDumpDate bool) (*Dumper, error) {
 	if !isDir(dir) {
 		return nil, errors.New("Invalid directory")
 	}
 
 	return &Dumper{
-		db:     db,
-		format: format,
-		dir:    dir,
+		db:              db,
+		format:          format,
+		dir:             dir,
+		includeDumpDate: includeDumpDate,
 	}, nil
 }
 


### PR DESCRIPTION
It's not really convenient, when comparing dumps, to include the dump date. In my case, I was checking the hash of the dump and it was never the same even if there was no changes in the DB.

I added an option to not include the dump date. Since it modifies the `mysqldump.Register` signature, this is a breaking change. Because the version is `0.x.x`, I think that [it's OK](https://semver.org/#spec-item-4).