### PR TITLE
change Typo databse to database in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ func main() {
 	// Register database with mysqldump
 	dumper, err := mysqldump.Register(db, dumpDir, dumpFilenameFormat)
 	if err != nil {
-		fmt.Println("Error registering databse:", err)
+		fmt.Println("Error registering database:", err)
 		return
 	}
 


### PR DESCRIPTION
We found a minor typo in the Example in `README.md`.

```go
	// Register database with mysqldump
	dumper, err := mysqldump.Register(db, dumpDir, dumpFilenameFormat)
	if err != nil {
		fmt.Println("Error registering databse:", err)
		return
	}
```